### PR TITLE
Fix: transparent borders

### DIFF
--- a/drw.c
+++ b/drw.c
@@ -203,6 +203,8 @@ drw_clr_create(Drw *drw, Clr *dest, const char *clrname)
 	                       DefaultColormap(drw->dpy, drw->screen),
 	                       clrname, dest))
 		die("error, cannot allocate color '%s'", clrname);
+
+	dest->pixel |= 0xff << 24;
 }
 
 /* Wrapper to create color schemes. The caller has to call free(3) on the


### PR DESCRIPTION
fixing transparent borders that appear in some windows in dwm.

For the entire issue, look [here](https://github.com/yshui/picom/issues/285).

## Issue Faced

- The issue was when using alacritty terminal, it had transparent borders unlike other windows/apps which I was using irrespective of together or alone. I thought this probably be a problem in `picom` but after tweaking its config, looking at the documentation and issues, I searched about this problem it appeared [here](https://github.com/yshui/picom/issues/285). Now, going to [this](https://github.com/yshui/picom/issues/285#issuecomment-614541511), tells me it is a wm problem and it should be because we have tried everything with picom and it didn't get fixed. This is actually not a problem with `voidwm` but a problem with `dwm` itself.

## Solution

- To fix this, there are two ways of doing it. One to apply `alpha` patch to dwm but it will make the code messy and we need to update and manage another dwm patch. The other one was one liner and easier which is [this](https://github.com/szatanjl/dwm/commit/1529909466206016f2101457bbf37c67195714c8).

- Added this line `drw.c` and it works great.

- I have added those two lines here so if anyone in future uses `voidwm`, it will work as intended for them.

Let me know if you want to know more about this or need screenshots. There are screenshots available in the main issue in `picom` repo, but if needed I will provide them.